### PR TITLE
cmake support and generateStubs cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,13 @@
 *.idb
 *.pdb
 
+# CMake build directories and files
+build/
+cmake-build-*/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+install_manifest.txt
+CTestTestfile.cmake
+compile_commands.json
+

--- a/CMAKE_BUILD.md
+++ b/CMAKE_BUILD.md
@@ -1,0 +1,168 @@
+# CMake Build Instructions
+
+This document explains how to build the ccoreconf library using CMake.
+
+## Prerequisites
+
+- CMake 3.15 or higher
+- GCC or compatible C compiler
+- nanocbor library
+
+## Basic Build
+
+### 1. Configure the build
+
+```bash
+mkdir build
+cd build
+cmake ..
+```
+
+### 2. Build the library
+
+```bash
+cmake --build .
+```
+
+This will create:
+- `build/libccoreconf.a` - The static library
+- `build/examples/` - Example executables (if enabled)
+
+## Specifying nanocbor Location
+
+If nanocbor is installed in a non-standard location, you can specify its path:
+
+### Using environment variables
+
+```bash
+export NANOCBOR_INCLUDE=/path/to/nanocbor/include
+export NANOCBOR_BUILD=/path/to/nanocbor/lib
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+### Using CMake variables
+
+```bash
+mkdir build && cd build
+cmake -DNANOCBOR_INCLUDE=/path/to/nanocbor/include \
+      -DNANOCBOR_BUILD=/path/to/nanocbor/lib \
+      ..
+cmake --build .
+```
+
+## Build Options
+
+### Build without examples
+
+```bash
+cmake -DBUILD_EXAMPLES=OFF ..
+cmake --build .
+```
+
+### Specify build type
+
+```bash
+# Debug build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+# Release build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+```
+
+## Installation
+
+To install the library and headers to your system:
+
+```bash
+cd build
+sudo cmake --install .
+```
+
+By default, this installs:
+- Library to `/usr/local/lib/libccoreconf.a`
+- Headers to `/usr/local/include/ccoreconf/`
+- Examples to `/usr/local/bin/examples/` (if built)
+
+To change the installation prefix:
+
+```bash
+cmake -DCMAKE_INSTALL_PREFIX=/your/custom/path ..
+cmake --build .
+cmake --install .
+```
+
+## Running Examples
+
+After building with examples enabled:
+
+```bash
+# From the build directory
+./examples/demo_functionalities_coreconf
+./examples/coreconf_types_example
+./examples/example_memory_tests
+./examples/example_nanocbor
+```
+
+## Cleaning the Build
+
+To clean and rebuild:
+
+```bash
+# Remove the build directory
+rm -rf build
+
+# Or use CMake's clean target
+cd build
+cmake --build . --target clean
+```
+
+## Integration with Other CMake Projects
+
+To use ccoreconf in your CMake project:
+
+```cmake
+# Add ccoreconf subdirectory
+add_subdirectory(path/to/ccoreconf)
+
+# Link your target with ccoreconf
+target_link_libraries(your_target PRIVATE ccoreconf)
+```
+
+Or if ccoreconf is installed system-wide:
+
+```cmake
+find_library(CCORECONF_LIB ccoreconf)
+target_link_libraries(your_target PRIVATE ${CCORECONF_LIB})
+target_include_directories(your_target PRIVATE /usr/local/include/ccoreconf)
+```
+
+## Troubleshooting
+
+### nanocbor not found
+
+If CMake cannot find nanocbor, ensure:
+1. nanocbor is properly installed
+2. `NANOCBOR_INCLUDE` and `NANOCBOR_BUILD` are set correctly
+3. The nanocbor library file is named `libnanocbor.a` or `libnanocbor.so`
+
+### Compiler errors
+
+Make sure you're using a C11-compatible compiler:
+```bash
+cmake -DCMAKE_C_COMPILER=gcc ..
+```
+
+## Comparison with Make
+
+The CMake build provides the same functionality as the Makefile:
+
+| Makefile | CMake Equivalent |
+|----------|------------------|
+| `make` | `cmake --build .` |
+| `make clean` | `cmake --build . --target clean` |
+| `make ccoreconf.a` | `cmake --build . --target ccoreconf` |
+| `NANOCBOR_INCLUDE=...` | `cmake -DNANOCBOR_INCLUDE=...` |
+
+Both build systems can coexist in the repository.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(ccoreconf
+    VERSION 1.0.0
+    DESCRIPTION "CORECONF (CoAP Management Interface) library"
+    LANGUAGES C
+)
+
+# Set C standard
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Compiler flags matching the Makefile
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Werror")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=strict-prototypes -Werror=format")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=old-style-definition -Werror=cast-align")
+
+# Option to build examples
+option(BUILD_EXAMPLES "Build example programs" ON)
+
+# Find nanocbor library
+# Users can specify NANOCBOR_INCLUDE and NANOCBOR_BUILD via cmake -D flags
+if(DEFINED ENV{NANOCBOR_INCLUDE} OR NANOCBOR_INCLUDE)
+    if(NOT NANOCBOR_INCLUDE)
+        set(NANOCBOR_INCLUDE $ENV{NANOCBOR_INCLUDE})
+    endif()
+    include_directories(${NANOCBOR_INCLUDE})
+endif()
+
+if(DEFINED ENV{NANOCBOR_BUILD} OR NANOCBOR_BUILD)
+    if(NOT NANOCBOR_BUILD)
+        set(NANOCBOR_BUILD $ENV{NANOCBOR_BUILD})
+    endif()
+    link_directories(${NANOCBOR_BUILD})
+endif()
+
+# Library source files
+set(CCORECONF_SOURCES
+    src/coreconfManipulation.c
+    src/coreconfTypes.c
+    src/hashmap.c
+    src/serialization.c
+    src/sid.c
+)
+
+# Library header files
+set(CCORECONF_HEADERS
+    include/coreconfManipulation.h
+    include/coreconfTypes.h
+    include/hashmap.h
+    include/serialization.h
+    include/sid.h
+)
+
+# Create static library
+add_library(ccoreconf STATIC ${CCORECONF_SOURCES} ${CCORECONF_HEADERS})
+
+# Set include directories for the library
+target_include_directories(ccoreconf
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+# Link nanocbor
+target_link_libraries(ccoreconf PUBLIC nanocbor)
+
+# Set output directory
+set_target_properties(ccoreconf PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+# Build examples if requested
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+# Installation rules
+install(TARGETS ccoreconf
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)
+
+install(FILES ${CCORECONF_HEADERS}
+    DESTINATION include/ccoreconf
+)
+
+# Print configuration summary
+message(STATUS "")
+message(STATUS "ccoreconf configuration summary:")
+message(STATUS "  Version: ${PROJECT_VERSION}")
+message(STATUS "  C Compiler: ${CMAKE_C_COMPILER}")
+message(STATUS "  Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Build examples: ${BUILD_EXAMPLES}")
+if(NANOCBOR_INCLUDE)
+    message(STATUS "  nanocbor include: ${NANOCBOR_INCLUDE}")
+endif()
+if(NANOCBOR_BUILD)
+    message(STATUS "  nanocbor library: ${NANOCBOR_BUILD}")
+endif()
+message(STATUS "")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ This library intends to provide tools for IoT projects to implement this protoco
 3. To manipulate CORECONF model: Once you can query the node, you should be able to modify/update the node using the functional interfaces.
 
 ## How to set it up?
+This project can be built using either CMake or VSCode/Make.
+
+### Building with CMake
+```bash
+mkdir build && cd build
+cmake -DNANOCBOR_INCLUDE=/path/to/nanocbor/include \
+      -DNANOCBOR_BUILD=/path/to/nanocbor/lib ..
+cmake --build .
+```
+
+See [CMAKE_BUILD.md](CMAKE_BUILD.md) for detailed CMake build instructions.
+
+### Building with VSCode
 This is a VSCode project. It depends on libraries such as: [nanocbor](https://github.com/bergzand/NanoCBOR). Once these library/libraries have been setup, update the tasks.json and c_cpp_properties.json files in .vscode/ to be able to build any examples.
 
 ## Enough talk, show me some code.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Examples CMakeLists.txt
+
+# Demo functionalities example
+add_executable(demo_functionalities_coreconf
+    demo_functionalities_coreconf.c
+)
+
+target_link_libraries(demo_functionalities_coreconf
+    PRIVATE ccoreconf
+)
+
+# CoreConf types example
+add_executable(coreconf_types_example
+    coreconf_types_example.c
+)
+
+target_link_libraries(coreconf_types_example
+    PRIVATE ccoreconf
+)
+
+# Memory tests example
+add_executable(example_memory_tests
+    example_memory_tests.c
+)
+
+target_link_libraries(example_memory_tests
+    PRIVATE ccoreconf
+)
+
+# NanoCBOR example
+add_executable(example_nanocbor
+    example_nanocbor.c
+)
+
+target_link_libraries(example_nanocbor
+    PRIVATE
+    ccoreconf
+    jansson
+)
+
+# Set output directory for examples
+set_target_properties(
+    demo_functionalities_coreconf
+    coreconf_types_example
+    example_memory_tests
+    example_nanocbor
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples
+)
+
+# Installation (optional)
+install(TARGETS
+    demo_functionalities_coreconf
+    coreconf_types_example
+    example_memory_tests
+    example_nanocbor
+    RUNTIME DESTINATION bin/examples
+)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,8 +3,8 @@ CFLAGS=-fdiagnostics-color=always -g -I/home/valentina/projects/lpwan_examples/b
 
 all: executable
 
-executable: hashmap.o sid.o fileOperations.o ccoreconf.o demo_functionalities.o
-	$(CC) $(CFLAGS) -o executable demo_functionalities.o hashmap.o sid.o fileOperations.o ccoreconf.o
+executable: hashmap.o sid.o coreconfTypes.o coreconfManipulation.o demo_functionalities.o
+	$(CC) $(CFLAGS) -o executable demo_functionalities.o hashmap.o sid.o coreconfTypes.o coreconfManipulation.o
 
 demo_functionalities.o: demo_functionalities.c
 	$(CC) $(CFLAGS) -c demo_functionalities.c
@@ -15,11 +15,11 @@ hashmap.o: ../src/hashmap.c
 sid.o: ../src/sid.c
 	$(CC) $(CFLAGS) -c ../src/sid.c
 
-fileOperations.o: ../src/fileOperations.c
-	$(CC) $(CFLAGS) -c ../src/fileOperations.c
+coreconfManipulation.o: ../src/coreconfManipulation.c
+	$(CC) $(CFLAGS) -c ../src/coreconfManipulation.c
 
-ccoreconf.o: ../src/ccoreconf.c
-	$(CC) $(CFLAGS) -c ../src/ccoreconf.c
+coreconfTypes.o: ../src/coreconfTypes.c
+	$(CC) $(CFLAGS) -c ../src/coreconfTypes.c
 
 clean:
 	rm -f *.o executable

--- a/examples/coreconf_types_example.c
+++ b/examples/coreconf_types_example.c
@@ -7,7 +7,7 @@
 
 #include "../include/serialization.h"
 
-int main() {
+int main(void) {
     CoreconfValueT* arr_val = createCoreconfArray();
     CoreconfValueT* arr_val2 = createCoreconfArray();
     CoreconfValueT* internalMapValue = createCoreconfHashmap();

--- a/examples/example_memory_tests.c
+++ b/examples/example_memory_tests.c
@@ -5,7 +5,7 @@
  *  Key takeaways:
  * if pointer is already malloced then write a function with void return
  * if pointer is not allocted then write a function which mallocs and returns the pointer
-*/
+ */
 
 // Function to manipulate a pointer
 void manipulatePointer(int *ptr) {
@@ -14,22 +14,22 @@ void manipulatePointer(int *ptr) {
 }
 
 // DONT DO THIS
-void manipulatePointerMem(int *ptr){
-    // Allocate memory to pointer 
+void manipulatePointerMem(int *ptr) {
+    // Allocate memory to pointer
     ptr = (int *)malloc(sizeof(int));
     // Dereference the pointer and manipulate its value
     *ptr = 101;
 }
 
-int* manipulatePointerWithReturn(){
+int *manipulatePointerWithReturn(void) {
     // Create a new int pointer in heap assign 102 value to it and return
     int *ptr = (int *)malloc(sizeof(int));
     *ptr = 102;
     return ptr;
 }
 
-int main() {
-    int *ptr, *ptr2;
+int main(void) {
+    int *ptr;
 
     // Allocate memory
     ptr = (int *)malloc(sizeof(int));
@@ -42,20 +42,16 @@ int main() {
 
     // Call the function to manipulate the pointer
     manipulatePointer(ptr);
-    //manipulatePointerMem(ptr2); // Invalid as ptr2 is not allocated in heap
 
     int *ptr3 = manipulatePointerWithReturn();
 
     // Print the manipulated value
     printf("Value at ptr: %d\n", *ptr);
-    //printf("Value at ptr2: %d\n", *ptr2);
+    // printf("Value at ptr2: %d\n", *ptr2);
     printf("Value at ptr3: %d\n", *ptr3);
 
     // Free allocated memory
     free(ptr);
-
-    // CANNOT free ptr2 as it is not allocated in heap
-    //free(ptr2);
     free(ptr3);
 
     return 0;

--- a/examples/example_nanocbor.c
+++ b/examples/example_nanocbor.c
@@ -1,8 +1,8 @@
-#include <stdio.h>
 #include <jansson.h>
 #include <nanocbor/nanocbor.h>
+#include <stdio.h>
 
-int main() {
+int main(void) {
     // Create a JSON object using Jansson
     json_t *jsonObj = json_object();
     json_object_set_new(jsonObj, "name", json_string("John Doe"));
@@ -10,11 +10,11 @@ int main() {
     json_object_set_new(jsonObj, "is_student", json_true());
 
     // Encode the JSON object into CBOR format using NanoCBOR
-    size_t cbor_buffer_size = 1024; // Adjust as needed
+    size_t cbor_buffer_size = 1024;  // Adjust as needed
     uint8_t cbor_buffer[cbor_buffer_size];
     nanocbor_encoder_t encoder;
     nanocbor_encoder_init(&encoder, cbor_buffer, cbor_buffer_size);
-    
+
     // Start encoding the JSON object
     nanocbor_fmt_map(&encoder, 3);
     nanocbor_put_tstr(&encoder, "name");
@@ -24,7 +24,7 @@ int main() {
     nanocbor_put_tstr(&encoder, "is_student");
     nanocbor_fmt_bool(&encoder, json_is_true(json_object_get(jsonObj, "is_student")));
     nanocbor_fmt_end_indefinite(&encoder);
-    //nanocbor_fmt_end(&encoder);
+    // nanocbor_fmt_end(&encoder);
 
     // Print the encoded CBOR data
     printf("Encoded CBOR data:\n");

--- a/tools/generateCBORDumps.py
+++ b/tools/generateCBORDumps.py
@@ -1,32 +1,9 @@
-# A tool which generates CBOR dumps of the given input file passed as a command line argument, the dump is later saved as uint8_t array in a .h file 
-# Usage: python3 generateCBORDumps.py data_instance.json sid_file.sid cborDumpHeader.h
-# Example python3 generateCBORDumps.py ../samples/simple_yang/sensor_instance.json ../samples/simple_yang/sensor@unknown_numerical.sid cborDumpsHeader.h
-
 import cbor2
-import sys
-import json
 import pycoreconf
+import argparse
 
-def recursivelyConvertJSONToPy(jsonData):
-    coreconf = {}
-    for key in jsonData:
-        if isinstance(jsonData[key], dict):
-            coreconf[int(key)] = recursivelyConvertJSONToPy(jsonData[key])
-        elif isinstance(jsonData[key], list):
-            coreconf[int(key)] = []
-            for i in range(len(jsonData[key])):
-                if isinstance(jsonData[key][i], dict):
-                    coreconf[int(key)].append(recursivelyConvertJSONToPy(jsonData[key][i]))
-                else:
-                    coreconf[int(key)].append(jsonData[key][i])
-        else:
-            coreconf[int(key)] = jsonData[key]
-    return coreconf
-
-def main():
-
-    # Header preprocessor string"
-    preprocessorString = """
+# Header preprocessor string"
+preprocessorString = """
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -40,22 +17,65 @@ def main():
 \n\n\n
 """
 
-    # Takes 3 arguments, first is the data json file, and the second is the .SID file, third is the output header file name
-    if len(sys.argv) != 4:
-        print("Usage: python3 generateCBORDumps.py sensor_data_instance.json sensor.sid expectedHeaderFileName.h")
-        sys.exit(1)
-    
-    sensorJsonData = sys.argv[1]
-    sensorSID = sys.argv[2]
-    outputFileName = sys.argv[3]
+
+def recursivelyConvertJSONToPy(jsonData):
+    coreconf = {}
+    for key in jsonData:
+        if isinstance(jsonData[key], dict):
+            coreconf[int(key)] = recursivelyConvertJSONToPy(jsonData[key])
+        elif isinstance(jsonData[key], list):
+            coreconf[int(key)] = []
+            for i in range(len(jsonData[key])):
+                if isinstance(jsonData[key][i], dict):
+                    coreconf[int(key)].append(
+                        recursivelyConvertJSONToPy(jsonData[key][i])
+                    )
+                else:
+                    coreconf[int(key)].append(jsonData[key][i])
+        else:
+            coreconf[int(key)] = jsonData[key]
+    return coreconf
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""A tool which generates CBOR dumps of the given input
+        file passed as a command line argument, the dump is later saved as
+        uint8_t array in a .h file"""
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        required=True,
+        type=str,
+        help="Instance data in json format",
+    )
+    parser.add_argument(
+        "-s",
+        "--sid",
+        nargs="+",
+        required=False,
+        type=str,
+        help="List of input .sid files",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        type=str,
+        help="Output header file name",
+    )
+    args = parser.parse_args()
+
+    sensorJsonData = args.input
+    sensorSIDs = args.sid
+    outputFileName = args.output
 
     # Make CORECONF representation of the JSON
-    coreconfModel = pycoreconf.CORECONFModel(sensorSID)
-    cborData = coreconfModel.toCORECONF(sensorJsonData)
-
-
-    # Convert into python data structure
-    coreconfModelPy = cbor2.loads(cborData)
+    if not isinstance(sensorSIDs, list):
+        sensorSIDs = [sensorSIDs]
+    coreconfModel = pycoreconf.CORECONFModel(sensorSIDs)
+    cborData = coreconfModel.encode_json(sensorJsonData)
 
     print("CORECONF Model")
     print(cborData)
@@ -66,7 +86,7 @@ def main():
 
     # Save the data into a file
     # Fix the output file name, its saved as .h file?
-    with open(outputFileName, 'w') as file:
+    with open(outputFileName, "w") as file:
         print("Data saved to " + outputFileName)
         file.write(preprocessorString)
         file.write("const uint8_t coreconfModelCBORBuffer" + "[] = {")
@@ -83,14 +103,9 @@ def main():
 
         file.write("};\n\n\n")
 
-
     # Extract the key mapping table from the SID file
-    keyMap = {}
-    sidModel = json.load(open(sensorSID))
-    keyMap = sidModel["key-mapping"]
-    if not keyMap:
-        return
-    
+    keyMap = coreconfModel.key_mapping
+
     # Key mapping table found
     print("Key Mapping Table found in the SID file:")
     print(keyMap)
@@ -105,9 +120,9 @@ def main():
     print(keyMappingCborData.hex())
 
     # Save the data into a the output file
-    with open(outputFileName, 'a') as file:
+    with open(outputFileName, "a") as file:
         print("Key mapping saved to " + outputFileName)
-     
+
         file.write("const uint8_t keyMappingCBORBuffer" + "[] = {")
         # Write the data into the file, if the last element, don't add a comma
         for i in range(len(keyMappingCborData)):

--- a/tools/generateStubs.py
+++ b/tools/generateStubs.py
@@ -5,6 +5,7 @@
 import argparse
 import json
 import cbor2
+import pycoreconf
 
 cborTypeToCMapping = {
     "uint8": "uint8_t",
@@ -19,13 +20,13 @@ cborTypeToCMapping = {
     "float64": "double",
     "decimal64": "double",
     "boolean": "bool",
-    "binary" : "bool",
+    "binary": "bool",
     "string": "char *",
     "bytes": "uint8_t *",
     "array": "uint8_t *",
-    "enum" : "enum",
-    "identityref" : "char *",   # Map identityref to a char* since we dont have identityMap
-    "void" : "void"
+    "enum": "enum",
+    "identityref": "char *",  # Map identityref to a char* since we dont have identityMap
+    "void": "void",
 }
 
 
@@ -43,17 +44,19 @@ defaultTypeValue = {
     "float64": "0",
     "decimal64": "0",
     "boolean": "false",
-    "binary" : "false",
+    "binary": "false",
     "string": "NULL",
     "bytes": "NULL",
     "array": "NULL",
-    "enum" : "enum",
-    "identityref" : "NULL",
-    "void" : "NULL"
+    "enum": "enum",
+    "identityref": "NULL",
+    "void": "NULL",
 }
 
+# TODO: Perhaps refactor to not use globals in the future?
 enumTypes = {}
 functionNameWithEnumTypes = {}
+
 
 def formatIdentifier(identifier):
     """
@@ -62,44 +65,25 @@ def formatIdentifier(identifier):
     # Capitalize the letter next to "-"
     while "-" in identifier:
         index = identifier.index("-")
-        identifier = identifier[:index] + identifier[index+1].upper() + identifier[index+2:]
+        identifier = (
+            identifier[:index] + identifier[index + 1].upper() + identifier[index + 2 :]
+        )
 
     identifier = identifier.replace("/", "_").replace(":", "_")
     # Remove the leading "_"
     if identifier[0] == "_":
         identifier = identifier[1:]
 
-    # Shorten it, take the last word after "_" and use it as the identifier
-    identifier = identifier.split("_")[-1]
+    # Shorten it, take the last two words and use that.
+    # The hope is that for most cases this is unique enough
+    id_name = "_".join([item for item in identifier.split("_")[-2:]])
 
-    return identifier
+    return id_name
 
-# Function to generate CBOR mapping of key-mapping
-def generateCBORMapping(keyMapping, identifierSIDKeyMapping):
+
+def generateSIDPreprocessors(model):
     """
-    Replace the string identifiers in keyMapping into SIDs
-    and dump it into CBOR mapping
-    """
-    # Replace identifiers in key, values of keyMapping with SIDs
-    sidKeyMapping = {}
-    for identifierKey, keyList in keyMapping.items():
-        # Find SID for identifierKey
-        sidKey = identifierKey # identifierSIDKeyMapping[identifierKey]
-        sidKeyMapping[sidKey] = []
-
-        for key in keyList:
-            sidKeyMapping[sidKey].append(key)
-    
-    # Dump the sidKeyMapping into CBOR mapping
-    cborMapping = cbor2.dumps(sidKeyMapping)
-    # Format the string to store as bytestrings in C
-    cborMapping = str(cborMapping).replace("b'","").replace("'","")
-    return cborMapping
-
-
-def generateSIDPreprocessors(items):
-    """
-    Take items as input and generate C headers for all the items
+    Take pycoreconf generated model as input and generate C headers for all the sids
     For each item which has a valid type, add a line
         # define LEAF LEAF_SID_NUMBER
     """
@@ -107,48 +91,63 @@ def generateSIDPreprocessors(items):
     leafIdentifierCount = {}
     cHeaders = ""
 
-    for item in items:
-        itemType = item.get("type")
-        formattedItemIdentifier =  formatIdentifier(item["identifier"])
-            
+    for identifier, sid in model.sids.items():
+        if identifier not in model.types:
+            continue
+
+        itemType = model.types[identifier]
+        formattedItemIdentifier = formatIdentifier(identifier)
+
         # Resolve Enumeration type
-        if type(itemType) == dict:
+        if isinstance(itemType, dict):
             functionName = formattedItemIdentifier
-            enumDefinition = ", ".join(f'{value} = {key}' for key, value in itemType.items()) 
+            enumDefinition = ", ".join(
+                f"{value} = {key}" for key, value in itemType.items()
+            )
             # Signal the code generator that this is an enum type
-            item["type"] = "enum"
             # Populate the enumTypes
             enumTypeName = functionName.title() + "Enum"
             enumTypes[enumTypeName] = enumDefinition
             functionNameWithEnumTypes[functionName] = enumTypeName
 
             # Add an alias in the header
-            cHeaders += "#define  SID_" + formattedItemIdentifier.upper() + " " * calculateSpaces + str(item["sid"]) + "\n"
+            cHeaders += (
+                "#define  SID_"
+                + formattedItemIdentifier.upper()
+                + " "
+                + str(sid)
+                + "\n"
+            )
 
             # Continue the next section
             continue
+        elif itemType in cborTypeToCMapping:
+            cHeaders += (
+                "#define  SID_"
+                + formattedItemIdentifier.upper()
+                + " "
+                + str(sid)
+                + "\n"
+            )
 
-        if itemType in cborTypeToCMapping:
-            # Check if formattedItemIdentifier is already in leafIdentifierCount
-            if formattedItemIdentifier in leafIdentifierCount:
-                leafIdentifierCount[formattedItemIdentifier] += 1
-                formattedItemIdentifier += str(leafIdentifierCount[formattedItemIdentifier])
-            else:
-                leafIdentifierCount[formattedItemIdentifier] = 0
-
-            # Take absolute value of the difference between 20 and len(identifier)
-            calculateSpaces = abs( 19 - len( formattedItemIdentifier) ) + 1 # +1 in case the difference is 0
-            cHeaders += "#define  SID_" + formattedItemIdentifier.upper() + " " * calculateSpaces + str(item["sid"]) + "\n"
     return cHeaders
 
-def generateFunctionPreprocessors(functionPrefix, item):
+
+def generateFunctionPreprocessors(functionPrefix, sid, identifier):
     """
     Construct function name and its SID and put them as synonyms in the preprocessor
     """
-    functionName = formatIdentifier(item["identifier"])
-    functionSID = item["sid"]
-    calculateSpaces = abs( 19 - len(functionName) ) + 1 # +1 in case the difference is 0
-    return "#define " + functionPrefix + functionName + " "*calculateSpaces + functionPrefix + str(functionSID) + "\n"
+    functionName = formatIdentifier(identifier)
+    return (
+        "#define "
+        + functionPrefix
+        + functionName
+        + " "
+        + functionPrefix
+        + str(sid)
+        + "\n"
+    )
+
 
 class SIDItem:
     def __init__(self, namespace, identifier, sid, type_=None, stable=False):
@@ -161,7 +160,7 @@ class SIDItem:
 
         if type_:
             # NOTE fix this later
-            if type(type_) == list:
+            if isinstance(type_, list):
                 self.type = "void"
             else:
                 self.type = type_
@@ -172,26 +171,26 @@ class SIDItem:
     def checkType(self):
         # Ideally this should come from libcbor?
         # Check if self.type is an ENUM
-        if type(self.type) != dict:
-            # Check if self.type in cborType 
-            if (self.type not in cborTypeToCMapping):
+        if not isinstance(self.type, dict):
+            # Check if self.type in cborType
+            if self.type not in cborTypeToCMapping:
                 print("Invalid type: " + self.type)
                 # NOTE treat Invalid types as string
                 self.type = "string"
-        
+
     def addSidKey(self, sidKeyItem):
         self.sidKeyItems.append(sidKeyItem)
-    
+
     def addFunctionPrototype(self, functionPrototype):
         self.functionPrototype = functionPrototype
-    
+
     def generateDocStrings(self):
         """
         Generate C documentation String for the sidKey of the form:
             /*
-            This is an autogenerated function associated to 
+            This is an autogenerated function associated to
             SID:
-            Module: 
+            Module:
             Identifier:
             function params: (ruleIdValue, ruleIdLength)
             Stable:
@@ -199,15 +198,21 @@ class SIDItem:
         """
         docStringTemplate = """
 /*
-    This is an autogenerated function associated to 
+    This is an autogenerated function associated to
     SID: %s
-    Module: %s 
+    Module: %s
     Identifier: %s
-    function params: %s
+    function params:%s
     Stable: %s
 */\n"""
 
-        docString = docStringTemplate % (self.sid, self.namespace, self.identifier, ", ".join([x.identifier for x in self.sidKeyItems]), str(self.stable))
+        docString = docStringTemplate % (
+            self.sid,
+            self.namespace,
+            self.identifier,
+            " , ".join([x.identifier for x in self.sidKeyItems]),
+            str(self.stable),
+        )
         return docString
 
     def generateFunctionBody(self):
@@ -221,14 +226,28 @@ class SIDItem:
 
         # If the type is enum, then initialize it differently
         if self.type == "enum":
-            leafInitialization = cborTypeToCMapping[self.type] + " " + functionNameWithEnumTypes.get(functionName, "") + " " + instanceName + ";\n\t"; 
-            leafReturn = "// Return the leaf \n"+ "    return " + instanceName + ";"
+            leafInitialization = (
+                cborTypeToCMapping[self.type]
+                + " "
+                + functionNameWithEnumTypes.get(functionName, "")
+                + " "
+                + instanceName
+                + ";\n\t"
+            )
+            leafReturn = "// Return the leaf \n" + "    return " + instanceName + ";"
 
         # If the type is void, then don't initialize the leaf, else initialize with default value
         elif self.type != "void":
-            leafInitialization = cborTypeToCMapping[self.type] + " " +  instanceName + "  = " + defaultTypeValue[self.type] + ";\n\t"
-            leafReturn = "// Return the leaf \n"+ "    return " + instanceName + ";"
-        
+            leafInitialization = (
+                cborTypeToCMapping[self.type]
+                + " "
+                + instanceName
+                + "  = "
+                + defaultTypeValue[self.type]
+                + ";\n\t"
+            )
+            leafReturn = "// Return the leaf \n" + "    return " + instanceName + ";"
+
         functionBodyTemplate = """{
     // Initialize the leaf if it has a return type with a default value;
     %s
@@ -237,7 +256,7 @@ class SIDItem:
 }
         """
 
-        functionBody = functionBodyTemplate % (leafInitialization, leafReturn);
+        functionBody = functionBodyTemplate % (leafInitialization, leafReturn)
         return functionBody
 
     def generateCGetMethods(self):
@@ -248,7 +267,7 @@ class SIDItem:
         # Don't do anything if the namespace is not "data"
         if self.namespace != "data":
             return ""
-        
+
         # generate docstrings
         docString = self.generateDocStrings()
 
@@ -261,11 +280,19 @@ class SIDItem:
 
         # If no sidKeyItems are found directly return the function string
         if not self.sidKeyItems:
-            functionPrototype = cborTypeToCMapping[self.type] + " " + functionNameWithEnumTypes.get(functionName, "")  + " " + readString + functionName + "(void)"
+            functionPrototype = (
+                cborTypeToCMapping[self.type]
+                + " "
+                + functionNameWithEnumTypes.get(functionName, "")
+                + " "
+                + readString
+                + functionName
+                + "(void)"
+            )
             functionString = docString + functionPrototype + functionBody + "\n"
-            
+
             # Add the function prototype to the list of function prototypes
-            self.addFunctionPrototype("%s;"%(functionPrototype))
+            self.addFunctionPrototype("%s;" % (functionPrototype))
             return functionString
 
         lastSidKeyItem = self.sidKeyItems[-1]
@@ -273,123 +300,69 @@ class SIDItem:
             # check if sidKeyItem is the last item in the list
             if sidKeyItem == lastSidKeyItem:
                 # if yes, then don't add the comma
-                functionArgs += cborTypeToCMapping[sidKeyItem.type] + " " +  formatIdentifier(sidKeyItem.identifier)   
+                functionArgs += (
+                    cborTypeToCMapping[sidKeyItem.type]
+                    + " "
+                    + formatIdentifier(sidKeyItem.identifier)
+                )
             else:
-                functionArgs += cborTypeToCMapping[sidKeyItem.type] + " " +  formatIdentifier(sidKeyItem.identifier) + ", "
+                functionArgs += (
+                    cborTypeToCMapping[sidKeyItem.type]
+                    + " "
+                    + formatIdentifier(sidKeyItem.identifier)
+                    + ", "
+                )
 
         # generate C function return type from the self.type
         functionReturnType = cborTypeToCMapping[self.type]
-        functionPrototype = functionReturnType + " " + functionNameWithEnumTypes.get(functionName, "") + " " + readString + functionName + "(" + functionArgs + ")"
+        functionPrototype = (
+            functionReturnType
+            + " "
+            + functionNameWithEnumTypes.get(functionName, "")
+            + " "
+            + readString
+            + functionName
+            + "("
+            + functionArgs
+            + ")"
+        )
         functionString = docString + functionPrototype + functionBody + "\n"
-        
+
         # Add the function prototype to the list of function prototypes
-        self.addFunctionPrototype("%s;"%(functionPrototype))
+        self.addFunctionPrototype("%s;" % (functionPrototype))
         return functionString
 
-def findIdentifierBlockBySID(sid, items):
-    """
-    Iterate through items and return the dictionary which matches the sid number
-    """
-    for item in items:
-        if item["sid"] == sid:
-            return item
-    return {}
 
-def findIdentifierBlockByIdentifier(identifier, items):
-    """
-    Iterate through items and return the dictionary which matches the identifier
-    """
-    for item in items:
-        if item["identifier"] == identifier:
-            return item
-    return {}
-
-def generateMapping(items):
-    """
-    NOTE items is not just dataItems, it is all the items in the sid file
-    Generate a dictionary of the form:
-    {
-        "identifier1": sid1,
-        "identifier2": sid2
-    }
-    """
-    identifierSIDKeyMapping = {}
-    sidKeyIdentifierMapping = {}
-    for item in items:
-        identifierSIDKeyMapping[item["identifier"]] = item["sid"]
-        sidKeyIdentifierMapping[item["sid"]] = item["identifier"]
-    return identifierSIDKeyMapping, sidKeyIdentifierMapping
-
-def getSetOfKeysOfKeyMapping(keyMapping, identifierSIDKeyMapping):
-    """
-    Returns a set of all the keys in keyMapping
-    """
-    keySet = set()
-    for identifierKey, keyList in keyMapping.items():
-        # Find SID for identifierKey
-        sidKey = identifierSIDKeyMapping[identifierKey]
-
-        for key in keyList:
-            keySet.add( identifierSIDKeyMapping[key])
-
-    return keySet
-
-def findKeysForLeaves(itemIdentifier, keyMapping, identifierSIDKeyMapping):
-    """
-    Returns a list of keys for a leafIdentifier
-    """
-    itemSID = identifierSIDKeyMapping[itemIdentifier]
-    requiredSIDKeys = []
-
-    # If itemIdentifier is itself in keyMapping, then add its keys to requiredSIDKeySet
-    if itemIdentifier in keyMapping:
-        sidKeys = keyMapping[itemIdentifier]
-        for sidKey in sidKeys:
-            requiredSIDKeys.append(identifierSIDKeyMapping[sidKey])
-
-    # Check if its parents are in keyMapping and add their keys to requiredSIDKeySet
-    identifier = itemIdentifier
-    while (identifier):
-        identifier = identifier.rsplit("/", 1)[0]
-        if identifier in keyMapping:
-            # Should you keep the sidKey : keyList or just the keyList in this set?
-            # Add the sidKey to requiredSIDKeys
-            sidKeys = keyMapping[identifier]
-            for sidKey in sidKeys:
-                requiredSIDKeys.append( identifierSIDKeyMapping[sidKey] )
-
-    return requiredSIDKeys
-
-def findKeysForLeavesBySID(itemSID, keyMapping, sidKeyIdentifierMapping, identifierSIDKeyMapping):
+def findKeysForLeavesBySID(itemSID, model):
     """
     Returns a list of keys for a leafSID
     """
-    
-    itemIdentifier = sidKeyIdentifierMapping[itemSID]
+
+    itemIdentifier = model.ids[itemSID]
     requiredSIDKeys = []
 
     print("DEETS", itemSID, itemIdentifier)
 
-    # If itemIdentifier is itself in keyMapping, then add its keys to requiredSIDKeySet
-    if itemSID in keyMapping:
-        sidKeys = keyMapping[itemSID]
+    # If itemIdentifier is itself in keyMapping, then add its keys to requiredSIDKeys
+    if str(itemSID) in model.key_mapping:
+        sidKeys = model.key_mapping[itemIdentifier]
         for sidKey in sidKeys:
             requiredSIDKeys.append(sidKey)
 
-    # Check if its parents are in keyMapping and add their keys to requiredSIDKeySet
+    # Check if its parents are in key_mapping and add their keys to requiredSIDKeys
     identifier = itemIdentifier
-    while (identifier):
+    while identifier:
         identifier = identifier.rsplit("/", 1)[0]
 
         if not identifier:
-            # Block entered when its parent
+            continue
+        if identifier not in model.sids:
             continue
 
-        currentItemSID = identifierSIDKeyMapping[identifier]
-        currentItemSIDStr = str(currentItemSID)
+        currentItemSID = model.sids[identifier]
 
-        if currentItemSIDStr in keyMapping:
-            sidKeys = keyMapping[currentItemSIDStr]
+        if currentItemSID in model.key_mapping:
+            sidKeys = model.key_mapping[identifier]
             for sidKey in sidKeys:
                 requiredSIDKeys.append(sidKey)
 
@@ -398,100 +371,104 @@ def findKeysForLeavesBySID(itemSID, keyMapping, sidKeyIdentifierMapping, identif
 
 def main():
     # write a command line parser to accept .sid file as input
-    parser = argparse.ArgumentParser(description='Generate a C header file with stubs for all the SID functions')
-    parser.add_argument('input', metavar='input', type=str, help='The input .sid file')
-    parser.add_argument('proto', metavar='proto', type=str, help='Two files will be generated, one with the function stubs and the other with the headers')
+    parser = argparse.ArgumentParser(
+        description="Generate a C header file with stubs for all the SID functions"
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        metavar="input",
+        nargs="+",
+        required=False,
+        type=str,
+        help="List of input .sid files",
+    )
+    parser.add_argument(
+        "proto",
+        metavar="proto",
+        type=str,
+        help="Two files will be generated, one with the function stubs and the other with the headers",
+    )
     args = parser.parse_args()
 
-    headersFile = "./%s" %args.proto + ".h"
-    stubsFile = "./%s" %args.proto + ".c"
+    headersFile = "./%s" % args.proto + ".h"
+    stubsFile = "./%s" % args.proto + ".c"
 
     # This will be put in the header file
     functionPrototypes = []
 
-    cIncludeString = "#include <stdlib.h>\n#include <stdint.h>\n#include <stdbool.h>\n#include <string.h>\n#include \"%s\"\n"%(args.proto + ".h")
+    cIncludeString = (
+        '#include <stdlib.h>\n#include <stdint.h>\n#include <stdbool.h>\n#include <string.h>\n#include "%s"\n'
+        % (args.proto + ".h")
+    )
     hIncludeString = "#include <stdlib.h>\n#include <stdint.h>\n#include <stdbool.h>\n#include <string.h>\n#include <cbor.h>\n\n"
 
-    # read the .sid file and parse it as JSON
-    with open(args.input, 'r') as f:
-        sidJSON = json.load(f)
+    file_list = args.file
+    if not isinstance(file_list, list):
+        file_list = [file_list]
 
-    # Read "key-mapping" from sidJSON
-    keyMapping = sidJSON["key-mapping"]
-
-    # Read "item" from sidJSON, add compatibility check as well 
-    items = sidJSON.get("item")
-    if not items:
-        items = sidJSON["items"]
-
-    identifierSIDKeyMapping, sidKeyIdentifierMapping = generateMapping(items)
-    # keySet is a set of all the keys which have been used in keyMapping
-    sidKeySet = keyMapping.keys()
-    #sidKeySet = getSetOfKeysOfKeyMapping(keyMapping, identifierSIDKeyMapping)
-
-
-    # Iterate through items and find items with namespace "data"
-    dataItems = []
-    for item in items:
-        if item["namespace"] == "data":
-            # check if item is in keyMapping
-            itemSID = item["sid"]
-            itemIdentifier = item["identifier"]
-            # NOTE Remember key-mapping now has identifiers in instead of SIDs
-            if itemIdentifier in keyMapping:
-                # Find out the keys for this item
-                sidKeys = keyMapping[itemIdentifier]
-
-            dataItems.append(item)
+    ccm = pycoreconf.CORECONFModel(file_list)
+    keyMappingKeysList = [
+        key for sublist in ccm.key_mapping.values() for key in sublist
+    ]
 
     # Contain all the contents of the H & C file
     hCode = ""
     cCode = ""
 
     # Iterate through dataItems and generate preprocessor directives for each item
-    preprocessorDirectives = generateSIDPreprocessors(dataItems)
+    preprocessorDirectives = generateSIDPreprocessors(ccm)
     hCode += preprocessorDirectives + "\n\n"
 
     # Iterate through dataItems and generate C code for each item
     hFunctionPrototypes = ""
-    for item in dataItems:
-        itemIdentifier = item["identifier"]
-        itemSID = item["sid"]
-        itemType = item.get("type")
-        # Ignore items which are keys
-        if itemSID in sidKeySet:
+    for identifier, sid in ccm.sids.items():
+        if identifier not in ccm.types:
             continue
 
-        
-        hCode += generateFunctionPreprocessors("read_", item)
+        itemType = ccm.types[identifier]
+        # Ignore items which are keys
+        if sid in keyMappingKeysList:
+            continue
+
+        hCode += generateFunctionPreprocessors("read_", sid, identifier)
 
         # Generate C code for this item
-        sidItem = SIDItem(item["namespace"], itemIdentifier, itemSID, itemType, item.get("stable", "false"))
-        # Find out the keys for this item
+        # TODO: Do we need to add back in support for stable/unstable?
+        sidItem = SIDItem(ccm.namespace[identifier], identifier, sid, itemType, False)
 
         # Generate C code for this item
-        #sidKeys = findKeysForLeaves(itemIdentifier, keyMapping, identifierSIDKeyMapping)
-        sidKeys = findKeysForLeavesBySID(itemSID, keyMapping, sidKeyIdentifierMapping, identifierSIDKeyMapping)
-       
+        # Find all additional keys that this sid requires based on key-mapping
+        sidKeys = findKeysForLeavesBySID(sid, ccm)
+
         # Find item block for corresponding sidKeys
         for sidKey in sidKeys:
-            # Find the sidKeyItem from items
-            sidKeyItemMap = findIdentifierBlockBySID(sidKey, items)
-            if not sidKeyItemMap:
-                raise Exception("No item found for sid key: " + str(sidKey["sid"]))
-            sidKeyItem = SIDItem(sidKeyItemMap["namespace"], sidKeyItemMap["identifier"], sidKeyItemMap["sid"], sidKeyItemMap.get("type"), item.get("stable"))
+            if sidKey not in ccm.ids:
+                raise Exception("No item found for sid key: " + sidKey)
+
+            # TODO: Do we need to handle stable/unstable?
+            sidKeyItem = SIDItem(
+                ccm.namespace[ccm.ids[sidKey]],
+                ccm.ids[sidKey],
+                sidKey,
+                ccm.types[ccm.ids[sidKey]],
+                False,
+            )
             sidItem.addSidKey(sidKeyItem)
 
         cCode += sidItem.generateCGetMethods() + "\n"
         hFunctionPrototypes += sidItem.functionPrototype + "\n"
 
     # Add CBOR mapping to the header file
-    cborMapping = generateCBORMapping(keyMapping, identifierSIDKeyMapping)
-    hCode += "\nchar* keyMapping = \"%s\";\n"%(cborMapping)
+    # Dump the key_mapping into CBOR mapping
+    cborMapping = cbor2.dumps(ccm.key_mapping)
+    # Format the string to store as bytestrings in C
+    cborMapping = str(cborMapping).replace("b'", "").replace("'", "")
+    hCode += '\nchar* keyMapping = "%s";\n' % (cborMapping)
 
     # Add enum type
     for enumTypeName, enumDefinition in enumTypes.items():
-        hCode += "enum %s {%s};\n"%(enumTypeName, enumDefinition)
+        hCode += "enum %s {%s};\n" % (enumTypeName, enumDefinition)
 
     # Add the function prototypes to the header file
     hCode += "\n\n" + hFunctionPrototypes
@@ -501,7 +478,7 @@ def main():
     print(hIncludeString)
     print(hCode)
     # Write the H code to headersFile
-    with open(headersFile, 'w') as f:
+    with open(headersFile, "w") as f:
         f.write(hIncludeString)
         f.write(hCode)
 
@@ -511,10 +488,9 @@ def main():
     print(cCode)
 
     # Write the C code to stubsFile
-    with open(stubsFile, 'w') as f:
+    with open(stubsFile, "w") as f:
         f.write(cIncludeString)
         f.write(cCode)
-    
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I'm getting around to trying to use ccoreconf, and I first need to do some cleanup of the python generator scripts. Some notes on the changes:

1. Adds support to build ccoreconf with cmake
2. I'm using pycoreconf now in generateStubs, as it already handles a lot of the work that was previously being done manually. So this resulted in removing several functions and simplifying other code. I needed to submit a PR for pycoreconf to add support to store namespaces, so right now this depends on [this PR](https://github.com/alex-fddz/pycoreconf/pull/23) getting merged. If Alex does not want to make that change, we will have to figure out another solution
3. I removed the `calculatedSpaces` formatting because I found it was very brittle as it assumes a certain maximum identifier length. So the formatting is a little less pretty, but it's agnostic to identifier length now.
4. Some small cleanup to `generateCBORDumps.py`
5. I ruff formatted the files, so that's in line with python style conventions.
