### PR TITLE
fix: Adds peekLong method to get SIDs without modifying hashmap

### DIFF
--- a/include/sid.h
+++ b/include/sid.h
@@ -73,7 +73,9 @@ typedef struct SIDModelStruct {
 DynamicLongListT *createDynamicLongList(void);
 void initializeDynamicLongList(DynamicLongListT *dynamicLongList);
 void addLong(DynamicLongListT *dynamicLongList, long value);
+long getLong(DynamicLongListT *dynamicLongList, bool removeFromList);
 long popLong(DynamicLongListT *dynamicLongList);
+long peekLong(DynamicLongListT *dynamicLongList);
 // Create a method to clone the Dynamiclist
 void cloneDynamicLongList(DynamicLongListT *originalDynamicLongList, DynamicLongListT *clonedDynamicLongList);
 // Create a method to sort the two lists

--- a/src/coreconfManipulation.c
+++ b/src/coreconfManipulation.c
@@ -117,7 +117,7 @@ PathNodeT *findRequirementForSID(uint64_t sid, struct hashmap *clookupHashmap, s
         }
 
         // get the parent SID from clookup->dynamicLongList
-        int64_t parentSID = popLong(clookup->dynamicLongList);
+        int64_t parentSID = peekLong(clookup->dynamicLongList);
 
         // if parentSID is 0 then break
         if (parentSID != 0) {

--- a/src/sid.c
+++ b/src/sid.c
@@ -99,17 +99,27 @@ void addLong(DynamicLongListT *dynamicLongList, long value) {
     dynamicLongList->longList[currentListSize] = value;
 }
 
-// pop the last value from dynamicLongList
-long popLong(DynamicLongListT *dynamicLongList) {
+// get the last value from dynamicLongList
+// with an option to remove the item from the list
+long getLong(DynamicLongListT *dynamicLongList, bool removeFromList) {
     // If its NULL, then do nothing
     if (!dynamicLongList) return 0;
     // If the list is empty, then return -1
     if (dynamicLongList->size == 0) return 0;
     long lastValue = dynamicLongList->longList[dynamicLongList->size - 1];
-    dynamicLongList->longList = (long *)realloc(dynamicLongList->longList, (dynamicLongList->size - 1) * sizeof(long));
-    dynamicLongList->size = dynamicLongList->size - 1;
+    if (removeFromList == true) {
+        dynamicLongList->longList =
+            (long *)realloc(dynamicLongList->longList, (dynamicLongList->size - 1) * sizeof(long));
+        dynamicLongList->size = dynamicLongList->size - 1;
+    }
     return lastValue;
 }
+
+// pop the last value from dynamicLongList
+long popLong(DynamicLongListT *dynamicLongList) { return getLong(dynamicLongList, true); }
+
+// peek the last value from dynamicLongList, do not remove it
+long peekLong(DynamicLongListT *dynamicLongList) { return getLong(dynamicLongList, false); }
 
 // Clone a DynamicLongListT
 void cloneDynamicLongList(DynamicLongListT *originalDynamicLongList, DynamicLongListT *clonedDynamicLongList) {


### PR DESCRIPTION
This addresses #18 

Modifications:
* Adds a `getLong()` method that takes an argument to remove an entry from the list
* Adds `peekLong()` that calls getLong without removing the entry, so we just get the SID value
* Updates `popLong()` to call getLong with the removal argument set to true
* Updates `findRequirementForSID()` to use `peekLong()`