### PR TITLE
Pass free function pointer to hashmap_new

### DIFF
--- a/include/sid.h
+++ b/include/sid.h
@@ -88,6 +88,7 @@ void printDynamicLongList(DynamicLongListT *dynamicLongList);
 
 uint64_t keyMappingHash(const void *item, uint64_t seed0, uint64_t seed1);
 int keyMappingCompare(const void *a, const void *b, void *udata);
+void keyMappingFree(void *item);
 
 int identifierSIDCompare(const void *a, const void *b, void *udata);
 uint64_t identifierSIDHash(const void *item, uint64_t seed0, uint64_t seed1);

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -242,7 +242,7 @@ int keyMappingHashMapToCBOR(struct hashmap* keyMappingHashMap, nanocbor_encoder_
 // Deserialize a CBOR buffer to a KeyMappingHashMap
 struct hashmap* cborToKeyMappingHashMap(nanocbor_value_t* value) {
     struct hashmap* keyMappingHashMap =
-        hashmap_new(sizeof(KeyMappingT), 0, 0, 0, keyMappingHash, keyMappingCompare, NULL, NULL);
+        hashmap_new(sizeof(KeyMappingT), 0, 0, 0, keyMappingHash, keyMappingCompare, keyMappingFree, NULL);
     nanocbor_value_t map;
     if (nanocbor_enter_map(value, &map) < NANOCBOR_OK) return NULL;
     int loopCounter = 0;
@@ -284,15 +284,4 @@ struct hashmap* cborToKeyMappingHashMap(nanocbor_value_t* value) {
     }
     nanocbor_leave_container(value, &map);
     return keyMappingHashMap;
-}
-
-void freeKeyMappingHashMap(struct hashmap* map) {
-    size_t iter = 0;
-    void* item;
-    while (hashmap_iter(map, &iter, &item)) {
-        KeyMappingT* keyMapping = (KeyMappingT*)item;
-        if (keyMapping->dynamicLongList) {
-            freeDynamicLongList(keyMapping->dynamicLongList);
-        }
-    }
 }

--- a/src/sid.c
+++ b/src/sid.c
@@ -179,6 +179,14 @@ uint64_t keyMappingHash(const void *item, uint64_t seed0, uint64_t seed1) {
     return hashmap_murmur(&(keyMapping->key), sizeof(uint64_t), seed0, seed1);
 }
 
+void keyMappingFree(void *item) {
+    KeyMappingT *keyMapping = (KeyMappingT *)item;
+    if (keyMapping && keyMapping->dynamicLongList) {
+        freeDynamicLongList(keyMapping->dynamicLongList);
+        keyMapping->dynamicLongList = NULL;
+    }
+}
+
 int identifierSIDCompare(const void *a, const void *b, void *udata) {
     // NOTE Keep it unused for compatibility reasons
     (void)udata;


### PR DESCRIPTION
Hey Manoj, I just rebased on top of your changes, and we had both added functions to free the keyMappings. I used an approach where you pass the function to `hashmap_new()`, so that the hashmap library will automatically call it when a map is freed. Let me know what you think of this approach.