### PR TITLE
Major update: jinja2 templates, generic sid handler layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LIBNANOCBOR = -lnanocbor
 
 
 # Include directories for external libraries
-INCLUDE_DIRS =  -I$(NANOCBOR_INCLUDE) -I$(ZCBOR_INCLUDE)
+INCLUDE_DIRS =  -I$(NANOCBOR_INCLUDE) -I$(ZCBOR_INCLUDE) -Iinclude
 
 # Library directories for external libraries
 LIB_DIRS =  -L$(NANOCBOR_BUILD) 

--- a/tools/generateCBORDumps.py
+++ b/tools/generateCBORDumps.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "cbor2",
+#     "jinja2",
+#     "pycoreconf @ git+ssh://git@github.com/budhe888/pycoreconf",
+# ]
+# ///
+
 # Example python3 generateCBORDumps.py ../samples/simple_yang/sensor_instance.json ../samples/simple_yang/sensor@unknown.sid cborDumpsHeader.h
 import cbor2
 import pycoreconf

--- a/tools/generateStubs.py
+++ b/tools/generateStubs.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "cbor2",
+#     "jinja2",
+#     "pycoreconf @ git+ssh://git@github.com/budhe888/pycoreconf",
+# ]
+# ///
+
 # Read a SID JSON file and Generate a C header file with stubs for all the SID functions
 
 # Import argparse and write a command line parser to accept .sid file as input


### PR DESCRIPTION
Apologies for how big this update is, but as I was trying to integrate ccoreconf into my coreconf server code, it was hard to find a good cut off for a single PR before getting to this point. This PR has a lot of changes:

## Autocoder Updates
* Switched `generateCBORDumps.py` and `generateStubs.py` to use jinja2 templates. This makes the templating a lot cleaner, and easier to maintain/modify.
* Added generic sid_handler layer (`sid_handlers.h/c`): The `generateStubs.py` template now generates code to allow the user application to register handlers for each SID. The autocoder by default generates code to retrieve SID values from the hash map and write values to the hash map, but it also makes calls to the autogenerated stubs that the user can copy and modify for any special handling they may want to do with the request. In the application layer now, the user just has to call `initializeSidHandlerRegistry()` and `registerGeneratedHandlers()`. Then based on the sid, you use the context to evoke the handler.
* All integer types in handler are treated as 64-bit because CBOR doesn't distinguish between different lengths, only in signedness

## C code updates
* Added #include guards to headers.
* cborToCoreconfValue can handle all integer lengths by using the nanocbor overflow flag to check 8, 16, 32, and 64 bit types in order. This should conform then to CBOR which only uses as many bytes as are needed.
* Added `navigateToParentContainer()` which is used for updating entries in the hash map
* Added `updateCoreconfArrayByKey()` which is used to update an array value in an ipatch request where the key is specified as a part of the map value
* Added `clookupFree()` that the user application can pass to `hashmap_new()` when creating the clookup datastore
* Updated `insertCoreconfHashMap()` to recursively merge the new map value
* Updated `if, else if, else if, ...` blocks in `coreconfTypes.c` with `switch` statements.